### PR TITLE
Prep gem for Ruby 4.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,22 @@
+version: v1.0
+name: Test Turbine
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu2404
+blocks:
+  - name: RSpec
+    task:
+      jobs:
+        - name: Test
+          commands:
+            - checkout
+            - sem-version ruby $RUBY_VERSION
+            - gem install bundler -v ">= 2.0"
+            - bundle install
+            - bundle exec rspec
+          matrix:
+            - env_var: RUBY_VERSION
+              values:
+                - '3.3'
+                - '4.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rspec'
-require 'support/coverage' if ENV['COVERAGE']
+require 'rspec/collection_matchers'
+require 'support/coverage'
 require 'turbine'
 
 Dir['./spec/{support,factories}/**/*.rb'].map do |file|
@@ -16,10 +17,7 @@ RSpec.configure do |config|
   config.filter_run(focus: true)
   config.run_all_when_everything_filtered = true
 
-  # Allow adding examples to a filter group with only a symbol.
-  config.treat_symbols_as_metadata_keys_with_true_values = true
-
   # Factories are enabled on in integration tests.
   config.include Turbine::Spec::Factories, type: :integration,
-    example_group: { file_path: %r{spec\/integration} }
+    file_path: %r{spec\/integration}
 end

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -1,18 +1,16 @@
-if ENV['COVERAGE']
-  require 'simplecov'
+require 'simplecov'
 
-  SimpleCov.start do
-    add_filter('/spec/')
+SimpleCov.start do
+  add_filter('/spec/')
 
-    add_group 'Core' do |src|
-      path = src.filename
+  add_group 'Core' do |src|
+    path = src.filename
 
-      path.include?('/lib/turbine/') &&
-        ! path.include?('/turbine/pipeline/') &&
-        ! path.include?('/turbine/traversal/') &&
-        ! path.end_with?('version.rb')
-    end
-    add_group 'Pipeline',  'lib/turbine/pipeline'
-    add_group 'Traversal', 'lib/turbine/traversal'
+    path.include?('/lib/turbine/') &&
+      ! path.include?('/turbine/pipeline/') &&
+      ! path.include?('/turbine/traversal/') &&
+      ! path.end_with?('version.rb')
   end
+  add_group 'Pipeline',  'lib/turbine/pipeline'
+  add_group 'Traversal', 'lib/turbine/traversal'
 end

--- a/spec/turbine/edge_spec.rb
+++ b/spec/turbine/edge_spec.rb
@@ -19,7 +19,7 @@ describe 'Turbine::Edge' do
     end
 
     context 'without a "to" node' do
-      it { expect(->{ Turbine::Edge.new }).to raise_error(ArgumentError) }
+      it { expect { Turbine::Edge.new }.to raise_error(ArgumentError) }
     end
 
     context 'without an "from" node' do

--- a/spec/turbine/graph_spec.rb
+++ b/spec/turbine/graph_spec.rb
@@ -49,7 +49,7 @@ describe 'Turbine::Graph' do
       before { graph.add(node) }
 
       it 'should raise a DuplicateNodeError' do
-        expect(->{ graph.add(Turbine::Node.new(:jay)) }).to raise_error(
+        expect { graph.add(Turbine::Node.new(:jay)) }.to raise_error(
           Turbine::DuplicateNodeError, /Graph already has a node with the key/)
       end
     end # when the key conflicts with an existing node

--- a/spec/turbine/node_spec.rb
+++ b/spec/turbine/node_spec.rb
@@ -25,7 +25,7 @@ describe 'Turbine::Node' do
 
   context 'creating a new node' do
     context 'without providing a key' do
-      it { expect(-> { Turbine::Node.new }).to raise_error(ArgumentError) }
+      it { expect { Turbine::Node.new }.to raise_error(ArgumentError) }
     end
 
     context 'providing no properties' do
@@ -187,7 +187,7 @@ describe 'Turbine::Node' do
       let!(:original) { gloria.connect_to(manny, :child) }
 
       it 'raises DuplicateEdgeError' do
-        expect(-> { gloria.connect_to(manny, :child) }).to raise_error(
+        expect { gloria.connect_to(manny, :child) }.to raise_error(
           Turbine::DuplicateEdgeError, /another edge already exists/i)
       end
     end # when an identical edge already exists

--- a/spec/turbine/pipeline/integration_spec.rb
+++ b/spec/turbine/pipeline/integration_spec.rb
@@ -62,16 +62,16 @@ module Turbine::Pipeline
       let(:pipeline)  { pump | transform | finalise }
 
       it 'call each segment the minimum number of times' do
-        transform.should_receive(:next).
-          exactly(2).times.and_return { pump.next }
+        expect(transform).to receive(:next).
+          exactly(2).times.and_invoke(-> { pump.next })
 
         2.times { pipeline.next }
       end
 
       it 'calls each segment when requesting all items' do
         # Once for each item, then once more to check for another...
-        transform.should_receive(:next).
-          exactly(11).times.and_return { pump.next }
+        expect(transform).to receive(:next).
+          exactly(11).times.and_invoke(-> { pump.next })
 
         pipeline.to_a
       end
@@ -91,8 +91,8 @@ module Turbine::Pipeline
       end
 
       it 'executes lazily' do
-        filter.should_receive(:next).
-          exactly(3).times.and_return { pump.next }
+        expect(filter).to receive(:next).
+          exactly(3).times.and_invoke(-> { pump.next })
 
         pipeline.take(3)
       end

--- a/spec/turbine/pipeline/journal_spec.rb
+++ b/spec/turbine/pipeline/journal_spec.rb
@@ -23,7 +23,7 @@ module Turbine::Pipeline
         pipe.to_a
         pipe.rewind
 
-        journal.source.should_receive(:next).and_raise(StopIteration)
+        expect(journal.source).to receive(:next).and_raise(StopIteration)
 
         journal.values
       end

--- a/spec/turbine/properties_spec.rb
+++ b/spec/turbine/properties_spec.rb
@@ -34,7 +34,7 @@ describe 'Turbine::Properties' do
     end
 
     it 'should raise an error when the argument is not a hash' do
-      expect(->{ model.properties = '' }).to raise_error(
+      expect { model.properties = '' }.to raise_error(
         Turbine::InvalidPropertiesError, /must be a Hash/)
     end
   end

--- a/spec/turbine/traversal/base_spec.rb
+++ b/spec/turbine/traversal/base_spec.rb
@@ -4,7 +4,7 @@ describe 'Turbine::Traversal::Base' do
   describe '#visit' do
     it 'should raise NotImplementedError' do
       enum = Turbine::Traversal::Base.new(Turbine::Node.new(:a), :out).to_enum
-      expect(->{ enum.each { |*| } }).to raise_error(NotImplementedError)
+      expect { enum.each { |*| } }.to raise_error(NotImplementedError)
     end
   end
 end

--- a/turbine.gemspec
+++ b/turbine.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake',  '>= 0.9.0'
   s.add_development_dependency 'rspec', '>= 2.11.0'
+  s.add_development_dependency 'rspec-collection_matchers'
 
   s.rdoc_options     = ['--charset=UTF-8']
   s.extra_rdoc_files = %w[LICENSE README.md]


### PR DESCRIPTION
#### Context

In an ongoing effort to prepare the internal gems for the upcoming Ruby4/Rails8 update, we updated their semaphore checks to use versions 3.3 and 4.0. Then run their RSpec tests locally against this 2 versions to identify any early issues (at gem level) and fix them.

#### Implemented changes

- refinery: Update Ruby version checks to 3.3/4.0
- fever: Update Ruby version checks to 3.3/4.0
- merit: Update Ruby version checks to 3.3/4.0 and add csv dependency
- atlas: Update Ruby version checks to 3.3/4.0 and lockfile/dependencies for Ruby 4.0 
- identity_rails: Add simplecov, update Ruby version checks to 3.3/4.0 and lockfile/dependencies for Ruby 4.0
- transformer: Add simplecov, unpin ruby-version then set Ruby version checks for 3.3/4.0 
- rubel: Add rspec and simplecov, fix some specs then set Ruby version checks for 3.3/4.0
- osmosis: Standarize simplecov, add bigdecimal dependency, fix some specs then set Ruby version checks for 3.3/4.0
- turbine: Standarize simplecov, add rspec-collection_matchers, fix specs then set Ruby version checks for 3.3/4.0

#### Related

Goes with pull requests:
- refinery: https://github.com/quintel/refinery/pull/63
- fever: https://github.com/quintel/fever/pull/2
- merit: https://github.com/quintel/merit/pull/160
- atlas: https://github.com/quintel/atlas/pull/187
- identity_rails: https://github.com/quintel/identity_rails/pull/7
- transformer: https://github.com/quintel/transformer/pull/19
- rubel: https://github.com/quintel/rubel/pull/1
- osmosis: https://github.com/quintel/osmosis/pull/1
- turbine: https://github.com/quintel/turbine/pull/5 [THIS ONE]

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review